### PR TITLE
fixing issue with zipped list subscription

### DIFF
--- a/graphite2pandas.py
+++ b/graphite2pandas.py
@@ -43,7 +43,7 @@ def g2p(url, localize='CET'):
     times, values, labels =  [], [], []
     for element in decoded_json:
         labels.append(element['target'])
-        datapoints = zip(*element['datapoints'])
+        datapoints = list(zip(*element['datapoints']))
         values.append(datapoints[0])
         times.append(datapoints[1])
     index = pandas.DatetimeIndex((numpy.array(times[0],dtype='datetime64[s]')))


### PR DESCRIPTION
Datapoints is a zip object of element['datapoints'] read from json.

In the next line datapoints[0] is called, but the item is a zip object and not a list. 
Wrapping the zip in list() creates a list which is then subscriptable.